### PR TITLE
Crash reading some .cif files with Windows line endings

### DIFF
--- a/layer2/CifFile.cpp
+++ b/layer2/CifFile.cpp
@@ -268,12 +268,20 @@ bool cif_file::parse(char*&& p) {
       if (*p)
         *(p++) = 0;
       prev = *p;
-    } else if (*p == ';' && islinefeed(prev)) { // will NULL the line feed before the closing semicolon
+    } else if (*p == ';' && islinefeed(prev)) {
+      // multi-line tokens start with ";" and end with "\n;"
+      // multi-line tokens cannot be keys, only values.
       keypossible.push_back(false);
       tokens.push_back(p + 1);
+      // advance until `\n;`
       while (*++p && !(islinefeed(*p) && p[1] == ';'));
+      // step to next line and null the line feed
       if (*p) {
         *p = 0;
+        // \r\n on Windows)
+        if (p - 1 > tokens.back() && *(p - 1) == '\r') {
+          *(p - 1) = 0;
+        }
         p += 2;
       }
       prev = ';';


### PR DESCRIPTION
See https://jira.schrodinger.com/browse/SHARED-7269 in Schrödinger bug tracking.

When a .cif file had windows line endings, we weren't treating
long cif data values correctly. Basically, we were
including the carriage return character in the data value!

A .cif long value looks like this:

    _pdbx_struct_assembly_gen.asym_id_list
    ;A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,AA,BA,CA,DA,EA,FA,GA,HA,IA,JA,KA,LA,MA,NA,OA,PA,QA,RA,SA,TA,UA,VA,WA,XA,YA,ZA,AB,BB,CB,DB,EB,FB,GB,HB,IB
    ;

where the key is "_pdbx_struct_assembly_gen.asym_id_list" and
the value is everything between the semicolons, excluding the
final line break. Before this commit, we removed a single
linebreak character before the `;`. After this commit, we
remove one or two line break characters.

This wouldn't show up in typical workflows, because the
.cif and .cif.gz files on RCSB use Linux line endings. We
only saw this because we unzip the .cif.gz files
line by line in one of our tests.